### PR TITLE
improve sending interface, and make some fixes

### DIFF
--- a/src/actions/messages/MESSAGE_DELETE.ts
+++ b/src/actions/messages/MESSAGE_DELETE.ts
@@ -18,6 +18,7 @@ export default class CoreAction extends Action {
 	}
 
 	public cache(data: Message): void {
+		data.deleted = true;
 		data.channel.messages.delete(data.id);
 	}
 

--- a/src/actions/messages/MESSAGE_DELETE_BULK.ts
+++ b/src/actions/messages/MESSAGE_DELETE_BULK.ts
@@ -20,6 +20,7 @@ export default class CoreAction extends Action {
 		for (const id of data.d.ids) {
 			const message = channel.messages.get(id);
 			if (message) {
+				message.deleted = true;
 				channel.messages.delete(id);
 				messages.push(message);
 			} else {

--- a/src/client/Client.ts
+++ b/src/client/Client.ts
@@ -15,10 +15,15 @@ import type { Store } from '../lib/structures/base/Store';
 import type { Piece } from '../lib/structures/base/Piece';
 import type { ClientUser } from './caching/structures/ClientUser';
 
+export interface PieceOptions {
+	createFolders: boolean;
+	disabledCoreTypes: string[];
+}
+
 export interface ClientOptions extends BaseClientOptions {
 	ws?: Partial<WSOptions>;
-	createPiecesFolders?: boolean;
-	disabledCorePieces?: string[];
+	pieces?: PieceOptions;
+	caching?: boolean;
 }
 
 /**

--- a/src/client/Client.ts
+++ b/src/client/Client.ts
@@ -37,7 +37,7 @@ export interface CacheLimits {
 }
 
 export interface ClientCacheOptions {
-	caching: boolean;
+	enabled: boolean;
 	limits: CacheLimits;
 }
 

--- a/src/client/Client.ts
+++ b/src/client/Client.ts
@@ -20,10 +20,31 @@ export interface PieceOptions {
 	disabledCoreTypes: string[];
 }
 
+export interface CacheLimits {
+	bans: number;
+	dms: number;
+	channels: number;
+	emojis: number;
+	members: number;
+	guilds: number;
+	invites: number;
+	reactions: number;
+	messages: number;
+	presences: number;
+	roles: number;
+	users: number;
+	voiceStates: number;
+}
+
+export interface CacheOptions {
+	caching: boolean;
+	limits: CacheLimits;
+}
+
 export interface ClientOptions extends BaseClientOptions {
 	ws?: Partial<WSOptions>;
 	pieces?: PieceOptions;
-	caching?: boolean;
+	cache?: CacheOptions;
 }
 
 /**

--- a/src/client/Client.ts
+++ b/src/client/Client.ts
@@ -15,7 +15,7 @@ import type { Store } from '../lib/structures/base/Store';
 import type { Piece } from '../lib/structures/base/Piece';
 import type { ClientUser } from './caching/structures/ClientUser';
 
-export interface PieceOptions {
+export interface ClientPieceOptions {
 	createFolders: boolean;
 	disabledCoreTypes: string[];
 }
@@ -36,15 +36,15 @@ export interface CacheLimits {
 	voiceStates: number;
 }
 
-export interface CacheOptions {
+export interface ClientCacheOptions {
 	caching: boolean;
 	limits: CacheLimits;
 }
 
 export interface ClientOptions extends BaseClientOptions {
 	ws?: Partial<WSOptions>;
-	pieces?: PieceOptions;
-	cache?: CacheOptions;
+	pieces?: ClientPieceOptions;
+	cache?: ClientCacheOptions;
 }
 
 /**

--- a/src/client/caching/stores/BanStore.ts
+++ b/src/client/caching/stores/BanStore.ts
@@ -38,7 +38,7 @@ export class BanStore extends DataStore<Ban> {
 		if (existing) return existing['_patch']();
 
 		const entry = new this.Holds(this.client, data, this.guild);
-		if (this.client.options.caching) this.set(entry.id, entry);
+		if (this.client.options.cache.caching) this.set(entry.id, entry);
 		return entry;
 	}
 

--- a/src/client/caching/stores/BanStore.ts
+++ b/src/client/caching/stores/BanStore.ts
@@ -29,17 +29,16 @@ export class BanStore extends DataStore<Ban> {
 	/**
 	 * Adds a new structure to this DataStore
 	 * @param data The data packet to add
-	 * @param cache If the data should be cached
 	 */
 	// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
 	// @ts-ignore
-	protected _add(data: GuildBanAddDispatch['d'], cache = true): Ban {
+	protected _add(data: GuildBanAddDispatch['d']): Ban {
 		const existing = this.get(data.user.id);
 		// eslint-disable-next-line dot-notation
 		if (existing) return existing['_patch']();
 
 		const entry = new this.Holds(this.client, data, this.guild);
-		if (cache) this.set(entry.id, entry);
+		if (this.client.options.caching) this.set(entry.id, entry);
 		return entry;
 	}
 

--- a/src/client/caching/stores/BanStore.ts
+++ b/src/client/caching/stores/BanStore.ts
@@ -22,7 +22,7 @@ export class BanStore extends DataStore<Ban> {
 	public readonly guild: Guild;
 
 	public constructor(client: Client, guild: Guild) {
-		super(client, extender.get('Ban'));
+		super(client, extender.get('Ban'), client.options.cache.limits.bans);
 		this.guild = guild;
 	}
 

--- a/src/client/caching/stores/BanStore.ts
+++ b/src/client/caching/stores/BanStore.ts
@@ -38,7 +38,7 @@ export class BanStore extends DataStore<Ban> {
 		if (existing) return existing['_patch']();
 
 		const entry = new this.Holds(this.client, data, this.guild);
-		if (this.client.options.cache.caching) this.set(entry.id, entry);
+		if (this.client.options.cache.enabled) this.set(entry.id, entry);
 		return entry;
 	}
 

--- a/src/client/caching/stores/DMChannelStore.ts
+++ b/src/client/caching/stores/DMChannelStore.ts
@@ -23,7 +23,7 @@ export class DMChannelStore extends DataStore<Channel> {
 		if (existing && existing.type === data.type) return existing['_patch'](data);
 
 		const entry = Channel.create(this.client, data);
-		if (entry && this.client.options.caching) this.set(entry.id, entry);
+		if (entry && this.client.options.cache.caching) this.set(entry.id, entry);
 		return entry;
 	}
 

--- a/src/client/caching/stores/DMChannelStore.ts
+++ b/src/client/caching/stores/DMChannelStore.ts
@@ -14,17 +14,16 @@ export class DMChannelStore extends DataStore<Channel> {
 	/**
 	 * Adds a new structure to this DataStore
 	 * @param data The data packet to add
-	 * @param cache If the data should be cached
 	 */
 	// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
 	// @ts-ignore
-	protected _add(data: APIChannelData, cache = true): Channel | null {
+	protected _add(data: APIChannelData): Channel | null {
 		const existing = this.get(data.id);
 		// eslint-disable-next-line dot-notation
 		if (existing && existing.type === data.type) return existing['_patch'](data);
 
 		const entry = Channel.create(this.client, data);
-		if (entry && cache) this.set(entry.id, entry);
+		if (entry && this.client.options.caching) this.set(entry.id, entry);
 		return entry;
 	}
 

--- a/src/client/caching/stores/DMChannelStore.ts
+++ b/src/client/caching/stores/DMChannelStore.ts
@@ -8,7 +8,7 @@ import type { Client } from '../../Client';
 export class DMChannelStore extends DataStore<Channel> {
 
 	public constructor(client: Client) {
-		super(client, extender.get('DMChannel'));
+		super(client, extender.get('DMChannel'), client.options.cache.limits.dms);
 	}
 
 	/**

--- a/src/client/caching/stores/DMChannelStore.ts
+++ b/src/client/caching/stores/DMChannelStore.ts
@@ -23,7 +23,7 @@ export class DMChannelStore extends DataStore<Channel> {
 		if (existing && existing.type === data.type) return existing['_patch'](data);
 
 		const entry = Channel.create(this.client, data);
-		if (entry && this.client.options.cache.caching) this.set(entry.id, entry);
+		if (entry && this.client.options.cache.enabled) this.set(entry.id, entry);
 		return entry;
 	}
 

--- a/src/client/caching/stores/GuildChannelStore.ts
+++ b/src/client/caching/stores/GuildChannelStore.ts
@@ -26,7 +26,7 @@ export class GuildChannelStore extends DataStore<GuildChannel> {
 		if (existing) return existing['_patch'](data);
 
 		const entry = Channel.create(this.client, data, this.guild) as GuildChannel;
-		if (this.client.options.caching) this.set(entry.id, entry);
+		if (this.client.options.cache.caching) this.set(entry.id, entry);
 		return entry;
 	}
 

--- a/src/client/caching/stores/GuildChannelStore.ts
+++ b/src/client/caching/stores/GuildChannelStore.ts
@@ -19,15 +19,14 @@ export class GuildChannelStore extends DataStore<GuildChannel> {
 	/**
 	 * Adds a new structure to this DataStore
 	 * @param data The data packet to add
-	 * @param cache If the data should be cached
 	 */
-	protected _add(data: APIChannelData, cache = true): GuildChannel {
+	protected _add(data: APIChannelData): GuildChannel {
 		const existing = this.get(data.id);
 		// eslint-disable-next-line dot-notation
 		if (existing) return existing['_patch'](data);
 
 		const entry = Channel.create(this.client, data, this.guild) as GuildChannel;
-		if (cache) this.set(entry.id, entry);
+		if (this.client.options.caching) this.set(entry.id, entry);
 		return entry;
 	}
 

--- a/src/client/caching/stores/GuildChannelStore.ts
+++ b/src/client/caching/stores/GuildChannelStore.ts
@@ -12,7 +12,7 @@ export class GuildChannelStore extends DataStore<GuildChannel> {
 	public readonly guild: Guild;
 
 	public constructor(client: Client, guild: Guild) {
-		super(client, extender.get('GuildChannel'));
+		super(client, extender.get('GuildChannel'), client.options.cache.limits.channels);
 		this.guild = guild;
 	}
 

--- a/src/client/caching/stores/GuildChannelStore.ts
+++ b/src/client/caching/stores/GuildChannelStore.ts
@@ -26,7 +26,7 @@ export class GuildChannelStore extends DataStore<GuildChannel> {
 		if (existing) return existing['_patch'](data);
 
 		const entry = Channel.create(this.client, data, this.guild) as GuildChannel;
-		if (this.client.options.cache.caching) this.set(entry.id, entry);
+		if (this.client.options.cache.enabled) this.set(entry.id, entry);
 		return entry;
 	}
 

--- a/src/client/caching/stores/GuildEmojiStore.ts
+++ b/src/client/caching/stores/GuildEmojiStore.ts
@@ -23,7 +23,7 @@ export class GuildEmojiStore extends DataStore<GuildEmoji> {
 		if (existing) return existing['_patch'](data);
 
 		const entry = new this.Holds(this.client, data);
-		if (this.client.options.cache.caching) this.set(entry.id, entry);
+		if (this.client.options.cache.enabled) this.set(entry.id, entry);
 		return entry;
 	}
 

--- a/src/client/caching/stores/GuildEmojiStore.ts
+++ b/src/client/caching/stores/GuildEmojiStore.ts
@@ -23,7 +23,7 @@ export class GuildEmojiStore extends DataStore<GuildEmoji> {
 		if (existing) return existing['_patch'](data);
 
 		const entry = new this.Holds(this.client, data);
-		if (this.client.options.caching) this.set(entry.id, entry);
+		if (this.client.options.cache.caching) this.set(entry.id, entry);
 		return entry;
 	}
 

--- a/src/client/caching/stores/GuildEmojiStore.ts
+++ b/src/client/caching/stores/GuildEmojiStore.ts
@@ -14,17 +14,16 @@ export class GuildEmojiStore extends DataStore<GuildEmoji> {
 	/**
 	 * Adds a new structure to this DataStore
 	 * @param data The data packet to add
-	 * @param cache If the data should be cached
 	 */
 	// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
 	// @ts-ignore
-	protected _add(data: APIEmojiData, cache = true): GuildEmoji {
+	protected _add(data: APIEmojiData): GuildEmoji {
 		const existing = this.get(data.id as string);
 		// eslint-disable-next-line dot-notation
 		if (existing) return existing['_patch'](data);
 
 		const entry = new this.Holds(this.client, data);
-		if (cache) this.set(entry.id, entry);
+		if (this.client.options.caching) this.set(entry.id, entry);
 		return entry;
 	}
 

--- a/src/client/caching/stores/GuildEmojiStore.ts
+++ b/src/client/caching/stores/GuildEmojiStore.ts
@@ -8,7 +8,7 @@ import type { GuildEmoji } from '../structures/guilds/GuildEmoji';
 export class GuildEmojiStore extends DataStore<GuildEmoji> {
 
 	public constructor(client: Client) {
-		super(client, extender.get('GuildEmoji'));
+		super(client, extender.get('GuildEmoji'), client.options.cache.limits.emojis);
 	}
 
 	/**

--- a/src/client/caching/stores/GuildMemberStore.ts
+++ b/src/client/caching/stores/GuildMemberStore.ts
@@ -18,17 +18,16 @@ export class GuildMemberStore extends DataStore<GuildMember> {
 	/**
 	 * Adds a new structure to this DataStore
 	 * @param data The data packet to add
-	 * @param cache If the data should be cached
 	 */
 	// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
 	// @ts-ignore
-	protected _add(data: MemberData, cache = true): GuildMember {
+	protected _add(data: MemberData): GuildMember {
 		const existing = this.get((data.user as APIUserData).id);
 		// eslint-disable-next-line dot-notation
 		if (existing) return existing['_patch'](data);
 
 		const entry = new this.Holds(this.client, data, this.guild);
-		if (cache) this.set(entry.id, entry);
+		if (this.client.options.caching) this.set(entry.id, entry);
 		return entry;
 	}
 

--- a/src/client/caching/stores/GuildMemberStore.ts
+++ b/src/client/caching/stores/GuildMemberStore.ts
@@ -27,7 +27,7 @@ export class GuildMemberStore extends DataStore<GuildMember> {
 		if (existing) return existing['_patch'](data);
 
 		const entry = new this.Holds(this.client, data, this.guild);
-		if (this.client.options.cache.caching) this.set(entry.id, entry);
+		if (this.client.options.cache.enabled) this.set(entry.id, entry);
 		return entry;
 	}
 

--- a/src/client/caching/stores/GuildMemberStore.ts
+++ b/src/client/caching/stores/GuildMemberStore.ts
@@ -11,7 +11,7 @@ export class GuildMemberStore extends DataStore<GuildMember> {
 	public readonly guild: Guild;
 
 	public constructor(client: Client, guild: Guild) {
-		super(client, extender.get('GuildMember'));
+		super(client, extender.get('GuildMember'), client.options.cache.limits.members);
 		this.guild = guild;
 	}
 

--- a/src/client/caching/stores/GuildMemberStore.ts
+++ b/src/client/caching/stores/GuildMemberStore.ts
@@ -27,7 +27,7 @@ export class GuildMemberStore extends DataStore<GuildMember> {
 		if (existing) return existing['_patch'](data);
 
 		const entry = new this.Holds(this.client, data, this.guild);
-		if (this.client.options.caching) this.set(entry.id, entry);
+		if (this.client.options.cache.caching) this.set(entry.id, entry);
 		return entry;
 	}
 

--- a/src/client/caching/stores/GuildStore.ts
+++ b/src/client/caching/stores/GuildStore.ts
@@ -7,7 +7,7 @@ import type { Client } from '../../Client';
 export class GuildStore extends DataStore<Guild> {
 
 	public constructor(client: Client) {
-		super(client, extender.get('Guild'));
+		super(client, extender.get('Guild'), client.options.cache.limits.guilds);
 	}
 
 }

--- a/src/client/caching/stores/InviteStore.ts
+++ b/src/client/caching/stores/InviteStore.ts
@@ -7,7 +7,7 @@ import type { Client } from '../../Client';
 export class InviteStore extends DataStore<Invite> {
 
 	public constructor(client: Client) {
-		super(client, extender.get('Invite'));
+		super(client, extender.get('Invite'), client.options.cache.limits.invites);
 	}
 
 }

--- a/src/client/caching/stores/MessageReactionStore.ts
+++ b/src/client/caching/stores/MessageReactionStore.ts
@@ -7,7 +7,7 @@ import type { MessageReaction } from '../structures/messages/MessageReaction';
 export class MessageReactionStore extends DataStore<MessageReaction> {
 
 	public constructor(client: Client) {
-		super(client, extender.get('MessageReaction'));
+		super(client, extender.get('MessageReaction'), client.options.cache.limits.reactions);
 	}
 
 }

--- a/src/client/caching/stores/MessageStore.ts
+++ b/src/client/caching/stores/MessageStore.ts
@@ -7,7 +7,7 @@ import type { Client } from '../../Client';
 export class MessageStore extends DataStore<Message> {
 
 	public constructor(client: Client) {
-		super(client, extender.get('Message'));
+		super(client, extender.get('Message'), client.options.cache.limits.messages);
 	}
 
 }

--- a/src/client/caching/stores/PresenceStore.ts
+++ b/src/client/caching/stores/PresenceStore.ts
@@ -27,7 +27,7 @@ export class PresenceStore extends DataStore<Presence> {
 		if (existing) return existing['_patch'](data);
 
 		const entry = new this.Holds(this.client, data);
-		if (this.client.options.caching) this.set(entry.id, entry);
+		if (this.client.options.cache.caching) this.set(entry.id, entry);
 		return entry;
 	}
 

--- a/src/client/caching/stores/PresenceStore.ts
+++ b/src/client/caching/stores/PresenceStore.ts
@@ -27,7 +27,7 @@ export class PresenceStore extends DataStore<Presence> {
 		if (existing) return existing['_patch'](data);
 
 		const entry = new this.Holds(this.client, data);
-		if (this.client.options.cache.caching) this.set(entry.id, entry);
+		if (this.client.options.cache.enabled) this.set(entry.id, entry);
 		return entry;
 	}
 

--- a/src/client/caching/stores/PresenceStore.ts
+++ b/src/client/caching/stores/PresenceStore.ts
@@ -18,17 +18,16 @@ export class PresenceStore extends DataStore<Presence> {
 	/**
 	 * Adds a new structure to this DataStore
 	 * @param data The data packet to add
-	 * @param cache If the data should be cached
 	 */
 	// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
 	// @ts-ignore
-	protected _add(data: APIPresenceUpdateData, cache = true): Presence {
+	protected _add(data: APIPresenceUpdateData): Presence {
 		const existing = this.get(data.user.id);
 		// eslint-disable-next-line dot-notation
 		if (existing) return existing['_patch'](data);
 
 		const entry = new this.Holds(this.client, data);
-		if (cache) this.set(entry.id, entry);
+		if (this.client.options.caching) this.set(entry.id, entry);
 		return entry;
 	}
 

--- a/src/client/caching/stores/PresenceStore.ts
+++ b/src/client/caching/stores/PresenceStore.ts
@@ -11,7 +11,7 @@ export class PresenceStore extends DataStore<Presence> {
 	public readonly guild: Guild;
 
 	public constructor(client: Client, guild: Guild) {
-		super(client, extender.get('Presence'));
+		super(client, extender.get('Presence'), client.options.cache.limits.presences);
 		this.guild = guild;
 	}
 

--- a/src/client/caching/stores/RoleStore.ts
+++ b/src/client/caching/stores/RoleStore.ts
@@ -27,7 +27,7 @@ export class RoleStore extends DataStore<Role> {
 		if (existing) return existing['_patch'](data);
 
 		const entry = new this.Holds(this.client, data, this.guild);
-		if (this.client.options.caching) this.set(entry.id, entry);
+		if (this.client.options.cache.caching) this.set(entry.id, entry);
 		return entry;
 	}
 

--- a/src/client/caching/stores/RoleStore.ts
+++ b/src/client/caching/stores/RoleStore.ts
@@ -27,7 +27,7 @@ export class RoleStore extends DataStore<Role> {
 		if (existing) return existing['_patch'](data);
 
 		const entry = new this.Holds(this.client, data, this.guild);
-		if (this.client.options.cache.caching) this.set(entry.id, entry);
+		if (this.client.options.cache.enabled) this.set(entry.id, entry);
 		return entry;
 	}
 

--- a/src/client/caching/stores/RoleStore.ts
+++ b/src/client/caching/stores/RoleStore.ts
@@ -11,7 +11,7 @@ export class RoleStore extends DataStore<Role> {
 	public readonly guild: Guild;
 
 	public constructor(client: Client, guild: Guild) {
-		super(client, extender.get('Role'));
+		super(client, extender.get('Role'), client.options.cache.limits.roles);
 		this.guild = guild;
 	}
 

--- a/src/client/caching/stores/RoleStore.ts
+++ b/src/client/caching/stores/RoleStore.ts
@@ -18,17 +18,16 @@ export class RoleStore extends DataStore<Role> {
 	/**
 	 * Adds a new structure to this DataStore
 	 * @param data The data packet to add
-	 * @param cache If the data should be cached
 	 */
 	// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
 	// @ts-ignore
-	protected _add(data: APIRoleData, cache = true): Role {
+	protected _add(data: APIRoleData): Role {
 		const existing = this.get(data.id);
 		// eslint-disable-next-line dot-notation
 		if (existing) return existing['_patch'](data);
 
 		const entry = new this.Holds(this.client, data, this.guild);
-		if (cache) this.set(entry.id, entry);
+		if (this.client.options.caching) this.set(entry.id, entry);
 		return entry;
 	}
 

--- a/src/client/caching/stores/UserStore.ts
+++ b/src/client/caching/stores/UserStore.ts
@@ -7,7 +7,7 @@ import type { Client } from '../../Client';
 export class UserStore extends DataStore<User> {
 
 	public constructor(client: Client) {
-		super(client, extender.get('User'));
+		super(client, extender.get('User'), client.options.cache.limits.users);
 	}
 
 }

--- a/src/client/caching/stores/VoiceStateStore.ts
+++ b/src/client/caching/stores/VoiceStateStore.ts
@@ -27,7 +27,7 @@ export class VoiceStateStore extends DataStore<VoiceState> {
 		if (existing) return existing['_patch'](data);
 
 		const entry = new this.Holds(this.client, data, this.guild);
-		if (this.client.options.caching) this.set(entry.id, entry);
+		if (this.client.options.cache.caching) this.set(entry.id, entry);
 		return entry;
 	}
 

--- a/src/client/caching/stores/VoiceStateStore.ts
+++ b/src/client/caching/stores/VoiceStateStore.ts
@@ -27,7 +27,7 @@ export class VoiceStateStore extends DataStore<VoiceState> {
 		if (existing) return existing['_patch'](data);
 
 		const entry = new this.Holds(this.client, data, this.guild);
-		if (this.client.options.cache.caching) this.set(entry.id, entry);
+		if (this.client.options.cache.enabled) this.set(entry.id, entry);
 		return entry;
 	}
 

--- a/src/client/caching/stores/VoiceStateStore.ts
+++ b/src/client/caching/stores/VoiceStateStore.ts
@@ -18,17 +18,16 @@ export class VoiceStateStore extends DataStore<VoiceState> {
 	/**
 	 * Adds a new structure to this DataStore
 	 * @param data The data packet to add
-	 * @param cache If the data should be cached
 	 */
 	// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
 	// @ts-ignore
-	protected _add(data: APIVoiceStatePartial, cache = true): VoiceState {
+	protected _add(data: APIVoiceStatePartial): VoiceState {
 		const existing = this.get(data.user_id);
 		// eslint-disable-next-line dot-notation
 		if (existing) return existing['_patch'](data);
 
 		const entry = new this.Holds(this.client, data, this.guild);
-		if (cache) this.set(entry.id, entry);
+		if (this.client.options.caching) this.set(entry.id, entry);
 		return entry;
 	}
 

--- a/src/client/caching/stores/VoiceStateStore.ts
+++ b/src/client/caching/stores/VoiceStateStore.ts
@@ -11,7 +11,7 @@ export class VoiceStateStore extends DataStore<VoiceState> {
 	public readonly guild: Guild;
 
 	public constructor(client: Client, guild: Guild) {
-		super(client, extender.get('VoiceState'));
+		super(client, extender.get('VoiceState'), client.options.cache.limits.voiceStates);
 		this.guild = guild;
 	}
 

--- a/src/client/caching/stores/base/DataStore.ts
+++ b/src/client/caching/stores/base/DataStore.ts
@@ -25,7 +25,7 @@ export class DataStore<S extends Structure> extends Cache<string, S> {
 		if (existing) return existing['_patch'](data);
 
 		const entry = new this.Holds(this.client, data);
-		if (this.client.options.caching) this.set(entry.id, entry);
+		if (this.client.options.cache.caching) this.set(entry.id, entry);
 		return entry;
 	}
 

--- a/src/client/caching/stores/base/DataStore.ts
+++ b/src/client/caching/stores/base/DataStore.ts
@@ -9,6 +9,9 @@ import type { Constructor } from '../../../../util/Extender';
  */
 export class DataStore<S extends Structure> extends Cache<string, S> {
 
+	/**
+	 * The cache limit of this DataStore
+	 */
 	#limit: number;
 
 	public constructor(public readonly client: Client, protected readonly Holds: Constructor<S>, limit: number, iterable?: Iterable<S>) {
@@ -17,6 +20,11 @@ export class DataStore<S extends Structure> extends Cache<string, S> {
 		if (iterable) for (const item of iterable) this._add(item);
 	}
 
+	/**
+	 * Sets a value to this DataStore taking into account the cache limit.
+	 * @param key The key of the value you are setting
+	 * @param value The value for the key you are setting
+	 */
 	public set(key: string, value: S): this {
 		if (this.#limit === 0) return this;
 		if (this.size >= this.#limit && !this.has(key)) this.delete(this.firstKey as string);

--- a/src/client/caching/stores/base/DataStore.ts
+++ b/src/client/caching/stores/base/DataStore.ts
@@ -9,9 +9,18 @@ import type { Constructor } from '../../../../util/Extender';
  */
 export class DataStore<S extends Structure> extends Cache<string, S> {
 
-	public constructor(public readonly client: Client, protected readonly Holds: Constructor<S>, iterable?: Iterable<S>) {
+	#limit = Infinity;
+
+	public constructor(public readonly client: Client, protected readonly Holds: Constructor<S>, limit: number, iterable?: Iterable<S>) {
 		super();
+		this.#limit = limit;
 		if (iterable) for (const item of iterable) this._add(item);
+	}
+
+	public set(key: string, value: S): this {
+		if (this.#limit === 0) return this;
+		if (this.size >= this.#limit && !this.has(key)) this.delete(this.firstKey as string);
+		return super.set(key, value);
 	}
 
 	/**

--- a/src/client/caching/stores/base/DataStore.ts
+++ b/src/client/caching/stores/base/DataStore.ts
@@ -19,13 +19,13 @@ export class DataStore<S extends Structure> extends Cache<string, S> {
 	 * @param data The data packet to add
 	 * @param cache If the data should be cached
 	 */
-	protected _add(data: { id: string, [k: string]: any }, cache = true): S {
+	protected _add(data: { id: string, [k: string]: any }): S {
 		const existing = this.get(data.id);
 		// eslint-disable-next-line dot-notation
 		if (existing) return existing['_patch'](data);
 
 		const entry = new this.Holds(this.client, data);
-		if (cache) this.set(entry.id, entry);
+		if (this.client.options.caching) this.set(entry.id, entry);
 		return entry;
 	}
 

--- a/src/client/caching/stores/base/DataStore.ts
+++ b/src/client/caching/stores/base/DataStore.ts
@@ -9,7 +9,7 @@ import type { Constructor } from '../../../../util/Extender';
  */
 export class DataStore<S extends Structure> extends Cache<string, S> {
 
-	#limit = Infinity;
+	#limit: number;
 
 	public constructor(public readonly client: Client, protected readonly Holds: Constructor<S>, limit: number, iterable?: Iterable<S>) {
 		super();

--- a/src/client/caching/stores/base/DataStore.ts
+++ b/src/client/caching/stores/base/DataStore.ts
@@ -25,7 +25,7 @@ export class DataStore<S extends Structure> extends Cache<string, S> {
 		if (existing) return existing['_patch'](data);
 
 		const entry = new this.Holds(this.client, data);
-		if (this.client.options.cache.caching) this.set(entry.id, entry);
+		if (this.client.options.cache.enabled) this.set(entry.id, entry);
 		return entry;
 	}
 

--- a/src/client/caching/structures/Attachment.ts
+++ b/src/client/caching/structures/Attachment.ts
@@ -1,94 +1,60 @@
-import { APIMessageAttachmentData } from '@klasa/dapi-types';
-import { Stream } from 'stream';
+import { basename } from 'path';
+import { Readable } from 'stream';
+import { promises as fsp } from 'fs';
+import fetch from 'node-fetch';
+import { pathExists } from 'fs-nextra';
+import { MessageAttachment } from './messages/MessageAttachment';
 
-/**
- * @see https://discord.com/developers/docs/resources/channel#attachment-object
- */
-export class Attachment implements APIMessageAttachmentData {
+import type { File } from '@klasa/rest';
 
-	/**
-	 * Attachment id.
-	 * @since 0.0.1
-	 */
-	public readonly id: string;
+export class Attachment {
 
-	/**
-	 * Name of file attached.
-	 * @since 0.0.1
-	 */
-	public filename: string;
+	public name?: string;
+	public file?: string | Readable | Buffer | MessageAttachment;
 
-	/**
-	 * Size of file in bytes.
-	 * @since 0.0.1
-	 */
-	public size: number;
-
-	/**
-	 * Source url of file.
-	 * @since 0.0.1
-	 */
-	public url: string;
-
-	/**
-	 * A proxied url of file.
-	 * @since 0.0.1
-	 */
-	public proxy_url: string;
-
-	/**
-	 * Height of file (if image).
-	 * @since 0.0.1
-	 */
-	public height: number | null;
-
-	/**
-	 * Width of file (if image).
-	 * @since 0.0.1
-	 */
-	public width: number | null;
-
-	/**
-	 * The file data.
-	 * @since 0.0.1
-	 */
-	public file?: Buffer | string | Stream | null;
-
-	public constructor(attachment: APIMessageAttachmentData) {
-		this.id = attachment.id;
-
-		this.filename = attachment.filename;
-
-		this.size = attachment.size;
-
-		this.url = attachment.url;
-
-		// eslint-disable-next-line @typescript-eslint/camelcase
-		this.proxy_url = attachment.proxy_url;
-
-		this.height = attachment.height || null;
-
-		this.width = attachment.width || null;
+	public constructor(attachment: Partial<Attachment> = {}) {
+		this.name = attachment.name;
+		this.file = attachment.file;
 	}
 
-	/**
-	 * Sets a file source, used to send attachments to Discord.
-	 * @since 0.0.1
-	 * @param file The file data source
-	 */
-	setFile(file: string | Stream | Buffer): this {
+	public setName(name: string): this {
+		this.name = name;
+		return this;
+	}
+
+	public setFile(file: string | Readable | Buffer | MessageAttachment): this {
 		this.file = file;
 		return this;
 	}
 
 	/**
-	 * Sets a file name.
-	 * @since 0.0.1
-	 * @param name The name of file attached
+	 * Resolves a stream, url, file location, or text into a buffer we can send to the api
 	 */
-	setName(name: string): this {
-		this.filename = name;
-		return this;
+	public async resolve(): Promise<File> {
+		if (!this.file) throw new Error('Cannot resolve a FileAttachment that doesn\'t include a file');
+
+		if (this.file instanceof Readable) {
+			this.name = this.name || 'file.dat';
+			const buffers = [];
+			for await (const buffer of this.file) buffers.push(buffer);
+			this.file = Buffer.concat(buffers);
+		} else if (Buffer.isBuffer(this.file)) {
+			this.name = this.name || 'file.txt';
+		} else if (this.file instanceof MessageAttachment) {
+			this.name = this.file.filename;
+			this.file = await (await fetch(this.file.url)).buffer();
+		} else if (/^https?:\/\//.test(this.file)) {
+			this.name = this.name || basename(this.file);
+			this.file = await (await fetch(this.file)).buffer();
+		} else if (await pathExists(this.file)) {
+			this.name = this.name || basename(this.file);
+			this.file = await fsp.readFile(this.file);
+		} else {
+			this.name = this.name || 'file.txt';
+			this.file = Buffer.from(this.file);
+		}
+
+		return this as File;
 	}
 
 }

--- a/src/client/caching/structures/Attachment.ts
+++ b/src/client/caching/structures/Attachment.ts
@@ -9,7 +9,14 @@ import type { File } from '@klasa/rest';
 
 export class Attachment {
 
+	/**
+	 * The name of the Attachment
+	 */
 	public name?: string;
+
+	/**
+	 * The unresolved file to send to the api
+	 */
 	public file?: string | Readable | Buffer | MessageAttachment;
 
 	public constructor(attachment: Partial<Attachment> = {}) {
@@ -17,11 +24,19 @@ export class Attachment {
 		this.file = attachment.file;
 	}
 
+	/**
+	 * Allows you to set the name of the attachment
+	 * @param name The name of the Attachment
+	 */
 	public setName(name: string): this {
 		this.name = name;
 		return this;
 	}
 
+	/**
+	 * Allows you to set the file of the attachment
+	 * @param file The unresolved file to send to the api
+	 */
 	public setFile(file: string | Readable | Buffer | MessageAttachment): this {
 		this.file = file;
 		return this;

--- a/src/client/caching/structures/Message.ts
+++ b/src/client/caching/structures/Message.ts
@@ -3,7 +3,7 @@ import { Structure } from './base/Structure';
 import { MessageMentions } from './messages/MessageMentions';
 import { Embed } from './Embed';
 import { MessageFlags } from '../../../util/bitfields/MessageFlags';
-import { Attachment } from './Attachment';
+import { MessageAttachment } from './messages/MessageAttachment';
 import { MessageReactionStore } from '../stores/MessageReactionStore';
 import { MessageReaction } from './messages/MessageReaction';
 
@@ -64,7 +64,7 @@ export class Message extends Structure {
 	 * The attached files.
 	 * @since 0.0.1
 	 */
-	public readonly attachments: Cache<string, Attachment>;
+	public readonly attachments: Cache<string, MessageAttachment>;
 
 	/**
 	 * Contents of the message.
@@ -199,7 +199,7 @@ export class Message extends Structure {
 			}
 		}
 
-		if (data.attachments) for (const attachment of data.attachments) this.attachments.set(attachment.id, new Attachment(attachment));
+		if (data.attachments) for (const attachment of data.attachments) this.attachments.set(attachment.id, new MessageAttachment(attachment));
 		if (data.embeds) for (const embed of data.embeds) this.embeds.push(new Embed(embed));
 
 		if (Reflect.has(data, 'pinned')) this.pinned = data.pinned as boolean;

--- a/src/client/caching/structures/Message.ts
+++ b/src/client/caching/structures/Message.ts
@@ -146,6 +146,12 @@ export class Message extends Structure {
 	 */
 	public flags!: MessageFlags;
 
+	/**
+	 * If the message is deleted
+	 * @since 0.0.1
+	 */
+	public deleted = false;
+
 	public constructor(client: Client, data: APIMessageData) {
 		super(client);
 		this.id = data.id;

--- a/src/client/caching/structures/Webhook.ts
+++ b/src/client/caching/structures/Webhook.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-dupe-class-members */
 import { Snowflake } from '@klasa/snowflake';
 import { Routes } from '@klasa/rest';
 import { WebhookMessageBuilder, WebhookMessageOptions } from './messages/WebhookMessageBuilder';
@@ -121,13 +122,17 @@ export class Webhook extends Structure {
 	 * Sends a message over the webhook
 	 * @param data Message data
 	 */
-	public async send(data: WebhookMessageOptions, splitOptions: SplitOptions = {}): Promise<Message[]> {
+	public async send(data: WebhookMessageOptions, splitOptions: SplitOptions): Promise<Message[]>
+	public async send(data: (message: WebhookMessageBuilder) => WebhookMessageBuilder, splitOptions: SplitOptions): Promise<Message[]>
+	public async send(data: WebhookMessageOptions | ((message: WebhookMessageBuilder) => WebhookMessageBuilder), splitOptions: SplitOptions = {}): Promise<Message[]> {
 		if (!this.token) throw new Error('The token on this webhook is unknown. You cannot send messages.');
+
+		const split = new WebhookMessageBuilder(typeof data === 'function' ? data(new WebhookMessageBuilder()) : data).split(splitOptions);
 
 		const endpoint = Routes.webhookTokened(this.id, this.token);
 		const responses = [];
 
-		for (const message of new WebhookMessageBuilder(data).split(splitOptions)) responses.push(this.client.api.post(endpoint, message));
+		for (const message of split) responses.push(this.client.api.post(endpoint, message));
 
 		const rawMessages = await Promise.all(responses);
 

--- a/src/client/caching/structures/Webhook.ts
+++ b/src/client/caching/structures/Webhook.ts
@@ -101,6 +101,7 @@ export class Webhook extends Structure {
 	 * The channel of this webhook
 	 */
 	get channel(): Channel | null {
+		// todo: This is broken from another change...
 		return (this.client as Client).dms.get(this.channelID) || null;
 	}
 
@@ -122,9 +123,9 @@ export class Webhook extends Structure {
 	 * Sends a message over the webhook
 	 * @param data Message data
 	 */
-	public async send(data: WebhookMessageOptions, splitOptions: SplitOptions): Promise<Message[]>
-	public async send(data: (message: WebhookMessageBuilder) => WebhookMessageBuilder, splitOptions: SplitOptions): Promise<Message[]>
-	public async send(data: WebhookMessageOptions | ((message: WebhookMessageBuilder) => WebhookMessageBuilder), splitOptions: SplitOptions = {}): Promise<Message[]> {
+	public async send(data: WebhookMessageOptions, splitOptions?: SplitOptions): Promise<Message[]>
+	public async send(data: (message: WebhookMessageBuilder) => WebhookMessageBuilder, splitOptions?: SplitOptions): Promise<Message[]>
+	public async send(data: WebhookMessageOptions | ((message: WebhookMessageBuilder) => WebhookMessageBuilder), splitOptions?: SplitOptions): Promise<Message[]> {
 		if (!this.token) throw new Error('The token on this webhook is unknown. You cannot send messages.');
 
 		const split = new WebhookMessageBuilder(typeof data === 'function' ? data(new WebhookMessageBuilder()) : data).split(splitOptions);

--- a/src/client/caching/structures/channels/GuildTextChannel.ts
+++ b/src/client/caching/structures/channels/GuildTextChannel.ts
@@ -57,6 +57,7 @@ export abstract class GuildTextChannel extends GuildChannel {
 	/**
 	 * Sends a message to the channel.
 	 * @param data The {@link MessageBuilder builder} to send.
+	 * @param options The split options for the message.
 	 * @since 0.0.1
 	 */
 	public async send(data: MessageOptions, options: SplitOptions): Promise<Message[]>

--- a/src/client/caching/structures/channels/GuildTextChannel.ts
+++ b/src/client/caching/structures/channels/GuildTextChannel.ts
@@ -59,10 +59,10 @@ export abstract class GuildTextChannel extends GuildChannel {
 	 * @param data The {@link MessageBuilder builder} to send.
 	 * @since 0.0.1
 	 */
-	public async send(data: MessageOptions, options: SendOptions): Promise<Message[]>
-	public async send(data: (message: MessageBuilder) => MessageBuilder, options: SendOptions): Promise<Message[]>
-	public async send(data: MessageOptions | ((message: MessageBuilder) => MessageBuilder), options: SendOptions = {}): Promise<Message[]> {
-		const split = (typeof data === 'function' ? data(new MessageBuilder()) : new MessageBuilder(data)).split(options.split);
+	public async send(data: MessageOptions, options: SplitOptions): Promise<Message[]>
+	public async send(data: (message: MessageBuilder) => MessageBuilder, options: SplitOptions): Promise<Message[]>
+	public async send(data: MessageOptions | ((message: MessageBuilder) => MessageBuilder), options: SplitOptions): Promise<Message[]> {
+		const split = (typeof data === 'function' ? data(new MessageBuilder()) : new MessageBuilder(data)).split(options);
 
 		const endpoint = Routes.channelMessages(this.id);
 		const responses = [];
@@ -72,7 +72,7 @@ export abstract class GuildTextChannel extends GuildChannel {
 		const rawMessages = await Promise.all(responses);
 
 		// eslint-disable-next-line dot-notation
-		return rawMessages.map(msg => this.messages['_add'](msg as APIMessageData, options.cache));
+		return rawMessages.map(msg => this.messages['_add'](msg as APIMessageData));
 	}
 
 	protected _patch(data: APIChannelData): this {

--- a/src/client/caching/structures/guilds/GuildMember.ts
+++ b/src/client/caching/structures/guilds/GuildMember.ts
@@ -50,7 +50,7 @@ export class GuildMember extends Structure {
 	/**
 	 * When the user started boosting the guild.
 	 * @since 0.0.1
-	 * @see https://support.discordapp.com/hc/en-us/articles/360028038352-Server-Boosting-
+	 * @see https://support.discord.com/hc/en-us/articles/360028038352-Server-Boosting-
 	 */
 	public premiumSince!: number | null;
 

--- a/src/client/caching/structures/messages/MessageAttachment.ts
+++ b/src/client/caching/structures/messages/MessageAttachment.ts
@@ -1,0 +1,67 @@
+import { APIMessageAttachmentData } from '@klasa/dapi-types';
+
+/**
+ * @see https://discord.com/developers/docs/resources/channel#attachment-object
+ */
+export class MessageAttachment implements APIMessageAttachmentData {
+
+	/**
+	 * Attachment id.
+	 * @since 0.0.1
+	 */
+	public readonly id: string;
+
+	/**
+	 * Name of file attached.
+	 * @since 0.0.1
+	 */
+	public filename: string;
+
+	/**
+	 * Size of file in bytes.
+	 * @since 0.0.1
+	 */
+	public size: number;
+
+	/**
+	 * Source url of file.
+	 * @since 0.0.1
+	 */
+	public url: string;
+
+	/**
+	 * A proxied url of file.
+	 * @since 0.0.1
+	 */
+	public proxy_url: string;
+
+	/**
+	 * Height of file (if image).
+	 * @since 0.0.1
+	 */
+	public height: number | null;
+
+	/**
+	 * Width of file (if image).
+	 * @since 0.0.1
+	 */
+	public width: number | null;
+
+	public constructor(attachment: APIMessageAttachmentData) {
+		this.id = attachment.id;
+
+		this.filename = attachment.filename;
+
+		this.size = attachment.size;
+
+		this.url = attachment.url;
+
+		// eslint-disable-next-line @typescript-eslint/camelcase
+		this.proxy_url = attachment.proxy_url;
+
+		this.height = attachment.height || null;
+
+		this.width = attachment.width || null;
+	}
+
+}

--- a/src/client/caching/structures/messages/MessageBuilder.ts
+++ b/src/client/caching/structures/messages/MessageBuilder.ts
@@ -1,11 +1,12 @@
 /* eslint-disable no-dupe-class-members */
 import { mergeDefault } from '@klasa/utils';
 
+import { Embed } from '../Embed';
+
 import type { File, RequestOptions } from '@klasa/rest';
 import type { APIEmbedData } from '@klasa/dapi-types';
 
 import type { RequiredExcept, PartialRequired } from '../../../../util/types/Util';
-import { Embed } from '../Embed';
 
 export interface MessageData {
 	content?: string;

--- a/src/client/caching/structures/messages/MessageBuilder.ts
+++ b/src/client/caching/structures/messages/MessageBuilder.ts
@@ -169,7 +169,7 @@ export class MessageBuilder implements RequiredExcept<MessageOptions, 'auth' | '
 	 * Splits this into multiple messages
 	 * @param param0 Options to split the message by
 	 */
-	public split({ maxLength = 2000, char = '\n', prepend = '', append = '' }: SplitOptions): RequestOptions[] {
+	public split({ maxLength = 2000, char = '\n', prepend = '', append = '' }: SplitOptions = {}): RequestOptions[] {
 		// If there isn't content, the message can't be split
 		if (!this.data.content) return [this];
 

--- a/src/client/caching/structures/messages/MessageReaction.ts
+++ b/src/client/caching/structures/messages/MessageReaction.ts
@@ -63,8 +63,7 @@ export class MessageReaction extends Structure {
 	 * @param options The options for the fetch
 	 */
 	public async fetch(options?: MessageReactionFetchOptions): Promise<this> {
-		const endpoint = Routes.messageReaction(this.message.channel.id, this.message.id, this.emoji.identifier);
-		const users = await this.client.api.get(endpoint, { query: options }) as APIUserData[];
+		const users = await this.client.api.get(Routes.messageReaction(this.message.channel.id, this.message.id, this.emoji.identifier), { query: options }) as APIUserData[];
 		for (const user of users) {
 			// eslint-disable-next-line dot-notation
 			this.users.set(user.id, this.client.users['_add'](user));

--- a/src/client/caching/structures/messages/WebhookMessageBuilder.ts
+++ b/src/client/caching/structures/messages/WebhookMessageBuilder.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-dupe-class-members */
 import { mergeDefault } from '@klasa/utils';
 
 import type { File, RequestOptions } from '@klasa/rest';
@@ -6,6 +7,7 @@ import type { APIEmbedData } from '@klasa/dapi-types';
 import { MessageBuilder, AllowedMentions } from './MessageBuilder';
 
 import type { RequiredExcept, PartialRequired } from '../../../../util/types/Util';
+import { Embed } from '../Embed';
 
 
 export interface WebhookMessageData {
@@ -68,9 +70,11 @@ export class WebhookMessageBuilder extends MessageBuilder implements RequiredExc
 	 * Adds an embed to this webhook message
 	 * @param embed The field name
 	 */
-	public addEmbed(embed: APIEmbedData): this {
+	public addEmbed(embed: APIEmbedData): this
+	public addEmbed(embed: (embed: Embed) => Embed): this
+	public addEmbed(embed: APIEmbedData | ((embed: Embed) => Embed)): this {
 		if (!this.data.embeds) this.data.embeds = [];
-		this.data.embeds.push(embed);
+		this.data.embeds.push(typeof embed === 'function' ? embed(new Embed()) : embed);
 		return this;
 	}
 
@@ -80,9 +84,11 @@ export class WebhookMessageBuilder extends MessageBuilder implements RequiredExc
 	 * @param deleteCount How many fields to delete
 	 * @param embed The field name to insert
 	 */
-	public spliceEmbed(index: number, deleteCount: number, embed?: APIEmbedData): this {
+	public spliceEmbed(index: number, deleteCount: number, embed?: APIEmbedData): this
+	public spliceEmbed(index: number, deleteCount: number, embed?: (embed: Embed) => Embed): this
+	public spliceEmbed(index: number, deleteCount: number, embed?: APIEmbedData | ((embed: Embed) => Embed)): this {
 		if (!this.data.embeds) this.data.embeds = [];
-		if (embed) this.data.embeds.splice(index, deleteCount, embed);
+		if (embed) this.data.embeds.splice(index, deleteCount, typeof embed === 'function' ? embed(new Embed()) : embed);
 		else this.data.embeds.splice(index, deleteCount);
 		return this;
 	}

--- a/src/client/caching/structures/messages/WebhookMessageBuilder.ts
+++ b/src/client/caching/structures/messages/WebhookMessageBuilder.ts
@@ -5,9 +5,9 @@ import type { File, RequestOptions } from '@klasa/rest';
 import type { APIEmbedData } from '@klasa/dapi-types';
 
 import { MessageBuilder, AllowedMentions } from './MessageBuilder';
+import { Embed } from '../Embed';
 
 import type { RequiredExcept, PartialRequired } from '../../../../util/types/Util';
-import { Embed } from '../Embed';
 
 
 export interface WebhookMessageData {

--- a/src/lib/structures/base/Store.ts
+++ b/src/lib/structures/base/Store.ts
@@ -107,7 +107,7 @@ export class Store<V extends Piece> extends Cache<string, V> {
 	 */
 	public async loadAll(): Promise<number> {
 		this.clear();
-		if (!this.client.options.disabledCorePieces.includes(this.name)) {
+		if (!this.client.options.pieces.disabledCoreTypes.includes(this.name)) {
 			for (const directory of this.coreDirectories) await Store.walk(this, directory);
 		}
 		await Store.walk(this);
@@ -179,7 +179,7 @@ export class Store<V extends Piece> extends Cache<string, V> {
 			const files = await scan(directory, { filter: (stats) => stats.isFile() && extname(stats.name) === '.js' });
 			return Promise.all([...files.keys()].map(file => store.load(directory, relative(directory, file).split(sep)) as Promise<T>));
 		} catch {
-			if (store.client.options.createPiecesFolders) {
+			if (store.client.options.pieces.createFolders) {
 				ensureDir(directory).catch(err => store.client.emit('error', err));
 			}
 

--- a/src/util/Constants.ts
+++ b/src/util/Constants.ts
@@ -16,7 +16,7 @@ export const ClientOptionsDefaults: Required<ClientOptions> = {
 		disabledCoreTypes: []
 	},
 	cache: {
-		caching: true,
+		enabled: true,
 		limits: {
 			bans: Infinity,
 			dms: Infinity,

--- a/src/util/Constants.ts
+++ b/src/util/Constants.ts
@@ -15,5 +15,22 @@ export const ClientOptionsDefaults: Required<ClientOptions> = {
 		createFolders: false,
 		disabledCoreTypes: []
 	},
-	caching: true
+	cache: {
+		caching: true,
+		limits: {
+			bans: Infinity,
+			dms: Infinity,
+			channels: Infinity,
+			emojis: Infinity,
+			members: Infinity,
+			guilds: Infinity,
+			invites: Infinity,
+			reactions: Infinity,
+			messages: 100,
+			presences: Infinity,
+			roles: Infinity,
+			users: Infinity,
+			voiceStates: Infinity
+		}
+	}
 };

--- a/src/util/Constants.ts
+++ b/src/util/Constants.ts
@@ -11,6 +11,9 @@ export const BaseClientOptionsDefaults: Required<BaseClientOptions> = {
 export const ClientOptionsDefaults: Required<ClientOptions> = {
 	...BaseClientOptionsDefaults,
 	ws: WSOptionsDefaults,
-	createPiecesFolders: true,
-	disabledCorePieces: []
+	pieces: {
+		createFolders: false,
+		disabledCoreTypes: []
+	},
+	caching: true
 };


### PR DESCRIPTION
MessageBuilder#setEmbed now also allows a callback to be passed to provide a base Embed instance to be used. Similar changes were made to improve WebhookMessageBuilder.

```js
new MessageBuilder()
  .setEmbed(embed => embed
    .setTitle('foo')
    .setDescription('bar')
  );
```
or the following like normal:
```js
new MessageBuilder()
  .setEmbed(embed);
```

GuildTextChannel#send has been corrected to the intended interface `send(data, splitOptions): Promise<Message[]>`. It also has allowed a callback with a MessageBuilder instance provided.

```js
channel.send(message => message
  .setContent('foo')
  .setEmbed(embed => embed
    .setTitle('foo')
    .setDescription('bar')
  )
);
```
or the following like normal:
```js
channel.send(message);
```

Attachment and MessageAttachment could not be the same interface because of different required and un-required types. They have been split, and ResolveFile from MessageBuilder has been moved to Attachment#resolve(), and now allows MessageAttachments as a resolvable.

```js
new MessageBuilder()
  .addFile(await new Attachment().addFile(url).resolve());
```